### PR TITLE
Kubernetes 1.22 compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,6 @@
     state: present
   with_items:
     - containerd
-    - aufs-tools
 
 - name: Create config directory
   become: True


### PR DESCRIPTION
On Debian Bullseye and with newer containerd, we no longer need aufs, so
lets drop it (its also no longer included in the distribution)
